### PR TITLE
Fix other guide link

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -184,7 +184,7 @@
             <div class="l-box-lrg pure-u-1 pure-u-md-2-5">
                 <h4>Getting started</h4>
 
-                <p>New users should check out the <a href="https://www.gitbook.com/book/edvin/tornadofx-guide/details">guide</a>
+                <p>New users should check out the <a href="https://edvin.gitbooks.io/tornadofx-guide/">guide</a>
                     to get an overview of the framework and it's features.</p>
 
                 <p>Not feeling like reading? We have a growing number of <a href="https://youtube.com/mredvinsyse">screencasts</a>


### PR DESCRIPTION
I missed the guide link under Getting Started when I updated the nav bar link.