### PR TITLE
Update Maven Central Links to https

### DIFF
--- a/src/main/java/io/tornadofx/admin/domain/MavenMetadata.kt
+++ b/src/main/java/io/tornadofx/admin/domain/MavenMetadata.kt
@@ -13,7 +13,7 @@ class MavenMetadata {
     }
 
     companion object {
-        fun getTornadoFX(): MavenMetadata = JAXB.unmarshal(URI.create("http://repo1.maven.org/maven2/no/tornado/tornadofx/maven-metadata.xml"), MavenMetadata::class.java)
+        fun getTornadoFX(): MavenMetadata = JAXB.unmarshal(URI.create("https://repo1.maven.org/maven2/no/tornado/tornadofx/maven-metadata.xml"), MavenMetadata::class.java)
 
     }
 }

--- a/src/main/java/io/tornadofx/admin/felix/FelixDownloadServlet.kt
+++ b/src/main/java/io/tornadofx/admin/felix/FelixDownloadServlet.kt
@@ -24,21 +24,21 @@ class FelixDownloadServlet : HttpServlet() {
         val HttpCoreVersion = "4.4.6"
 
         val FelixURI = URI.create("http://www-eu.apache.org/dist/felix/org.apache.felix.main.distribution-$FelixVersion.zip")
-        val JavaFXSupportURI = URI.create("http://repo1.maven.org/maven2/no/tornado/javafx-osgi/$JavaFXSupportVersion/javafx-osgi-$JavaFXSupportVersion.jar")
+        val JavaFXSupportURI = URI.create("https://repo1.maven.org/maven2/no/tornado/javafx-osgi/$JavaFXSupportVersion/javafx-osgi-$JavaFXSupportVersion.jar")
         val ConfigAdminURI = URI.create("http://www-eu.apache.org/dist/felix/org.apache.felix.configadmin-$ConfigAdminVersion.jar")
-        val JsonURI = URI.create("http://repo1.maven.org/maven2/org/glassfish/javax.json/$JsonVersion/javax.json-$JsonVersion.jar")
-        val JsonAPIURI = URI.create("http://repo1.maven.org/maven2/javax/json/javax.json-api/$JsonAPIVersion/javax.json-api-$JsonAPIVersion.jar")
-        val KotlinURI = URI.create("http://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-osgi-bundle/$KotlinVersion/kotlin-osgi-bundle-$KotlinVersion.jar")
-        val CommonsLoggingURI = URI.create("http://repo1.maven.org/maven2/commons-logging/commons-logging/$CommonsLoggingVersion/commons-logging-$CommonsLoggingVersion.jar")
-        val HttpClientURI = URI.create("http://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient-osgi/$HttpClientVersion/httpclient-osgi-$HttpClientVersion.jar")
-        val HttpCoreURI = URI.create("http://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore-osgi/$HttpCoreVersion/httpcore-osgi-$HttpCoreVersion.jar")
+        val JsonURI = URI.create("https://repo1.maven.org/maven2/org/glassfish/javax.json/$JsonVersion/javax.json-$JsonVersion.jar")
+        val JsonAPIURI = URI.create("https://repo1.maven.org/maven2/javax/json/javax.json-api/$JsonAPIVersion/javax.json-api-$JsonAPIVersion.jar")
+        val KotlinURI = URI.create("https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-osgi-bundle/$KotlinVersion/kotlin-osgi-bundle-$KotlinVersion.jar")
+        val CommonsLoggingURI = URI.create("https://repo1.maven.org/maven2/commons-logging/commons-logging/$CommonsLoggingVersion/commons-logging-$CommonsLoggingVersion.jar")
+        val HttpClientURI = URI.create("https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient-osgi/$HttpClientVersion/httpclient-osgi-$HttpClientVersion.jar")
+        val HttpCoreURI = URI.create("https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore-osgi/$HttpCoreVersion/httpcore-osgi-$HttpCoreVersion.jar")
     }
 
     override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {
         response.addHeader("Content-Type", "application/octet-stream")
 
         val TornadoFXVersion = MavenMetadata.getTornadoFX().versioning.latest
-        val TornadoFXURI = URI.create("http://repo1.maven.org/maven2/no/tornado/tornadofx/$TornadoFXVersion/tornadofx-$TornadoFXVersion.jar")
+        val TornadoFXURI = URI.create("https://repo1.maven.org/maven2/no/tornado/tornadofx/$TornadoFXVersion/tornadofx-$TornadoFXVersion.jar")
 
         ZipInputStream(FelixURI.toURL().openStream()).use { input ->
             ZipOutputStream(response.outputStream).use { output ->


### PR DESCRIPTION
This addresses the issue:

```
501 HTTPS Required.
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```

This issue manifests itself when you try to download archives such as:
https://tornadofx.io/felix-bundle.zip